### PR TITLE
[Feature] sc-25564 Generate the report url when report is uploaded

### DIFF
--- a/piperider_cli/stage_runner.py
+++ b/piperider_cli/stage_runner.py
@@ -42,7 +42,7 @@ class ReportAggregator(object):
         if piperider_app_url is None:
             return None
         self._report_uid = uid
-        self._report_url = f'{piperider_app_url}/report/{uid}'
+        self._report_url = f'{piperider_app_url}/reports/{uid}'
         return self._report_url
 
     def report(self):


### PR DESCRIPTION
 * Output the report URL to stdout when the test report is uploaded to piperider 
 * Use the environment variable PIPERIDER_APP_URL to configure the test report URL. (Default: https://app.piperider.io)

Signed-off-by: Kent Huang <me@kent-huang.dev>