### PR TITLE
Fix init error without the dbt profile

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -36,7 +36,7 @@ def version():
 @click.option('--provider', type=click.Choice(['dbt-local', 'customized']), default='dbt-local',
               help='Select the provider of datasource')
 @click.option('--dbt-project-path', type=click.Path(exists=True), default=None, help='Path of dbt project config')
-@click.option('--dbt-profile-path', type=click.Path(exists=True), default=os.path.expanduser('~/.dbt/profiles.yml'),
+@click.option('--dbt-profile-path', type=click.Path(exists=False), default=os.path.expanduser('~/.dbt/profiles.yml'),
               help='Path of dbt profile config')
 @add_options(debug_option)
 def init(**kwargs):


### PR DESCRIPTION
reproducible when there is no dbt profile.

```
root@2efe3ca2a8a8:/data#
root@2efe3ca2a8a8:/data# piperider-cli init
Usage: piperider-cli init [OPTIONS]
Try 'piperider-cli init --help' for help.

Error: Invalid value for '--dbt-profile-path': Path '/root/.dbt/profiles.yml' does not exist.
root@2efe3ca2a8a8:/data#
```