### PR TITLE
make no auto search as toggle

### DIFF
--- a/piperider_cli/cli.py
+++ b/piperider_cli/cli.py
@@ -45,7 +45,7 @@ def version():
 
 
 @cli.command(short_help='Initialize PipeRider configurations')
-@click.option('--no-auto-search', type=click.BOOL, default=False, help="Don't search for dbt projects")
+@click.option('--no-auto-search', type=click.BOOL, default=False, is_flag=True, help="Don't search for dbt projects")
 @click.option('--dbt-project-dir', type=click.Path(exists=True), default=None, help='Directory of dbt project config')
 @click.option('--dbt-profiles-dir', type=click.Path(exists=True), default=None, help='Directory of dbt profiles config')
 @add_options(debug_option)


### PR DESCRIPTION
Before
```
piperider-cli init --help
Usage: piperider-cli init [OPTIONS]

Options:
  --no-auto-search BOOLEAN  Don't search for dbt projects
  --dbt-project-dir PATH    Directory of dbt project config
  --dbt-profiles-dir PATH  Directory of dbt profiles config
  --debug                  Enable debug mode
  --help                   Show this message and exit.
```


After

```
piperider-cli init --help
Usage: piperider-cli init [OPTIONS]

Options:
  --no-auto-search         Don't search for dbt projects
  --dbt-project-dir PATH   Directory of dbt project config
  --dbt-profiles-dir PATH  Directory of dbt profiles config
  --debug                  Enable debug mode
  --help                   Show this message and exit.
```