### PR TITLE
Handle sqlite mismatched data

### DIFF
--- a/piperider_cli/profiler/profiler.py
+++ b/piperider_cli/profiler/profiler.py
@@ -198,7 +198,6 @@ class Profiler:
             )
             result = conn.execute(stmt).fetchone()
             _total, _non_null, _mismatched, _distinct, _sum, _avg, _min, _max = result
-            _mismatched = int(_mismatched)
             if is_integer:
                 _sum = int(_sum) if _sum is not None else None
                 _min = int(_min) if _min is not None else None


### PR DESCRIPTION
Ref:
https://www.sqlite.org/datatype3.html

sqlite mismatched

column type | mismatched types
-------------------|-------------------------------
integer           | text, blob (set value to null)
numeric         | text, blob (set value to null)
text                 | no
datetime        | no
other              | no


Currently principle is make profiler works for non-numeric profiling metrics.)