### PR TITLE
add packages for piperider-action image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir dbt-snowflake==1.1.0 snowflake-sqlalchemy==1.3.4 psycopg2-binary
 
 WORKDIR /usr/src/github/
 


### PR DESCRIPTION
check with `make docker-build`
```
=> [10/13] RUN apt-get update &&     apt-get install -y --no-install-recommends git     && apt-get purge -y --auto-remove     && rm -rf /var/lib/apt/lists/*               33.7s
 => [11/13] RUN pip install --no-cache-dir -r requirements.txt &&     pip install --no-cache-dir dbt-snowflake==1.1.0 snowflake-sqlalchemy==1.3.4 psycopg2-binary          151.5s
 => [12/13] WORKDIR /usr/src/github/                                                                                                                                         0.0s
 => [13/13] COPY entrypoint.sh /entrypoint.sh                                                                                                                                0.0s
 => exporting to image                                                                                                                                                       1.0s
 => => exporting layers                                                                                                                                                      1.0s
 => => writing image sha256:1a17d2e05c74faa557813f4d7f4ccaf45477f44bacb51c347d256d69edcb9ff9                                                                                 0.0s
 => => naming to docker.io/library/piperider-cli:0.1.3-dev
```

Signed-off-by: Wei-Chun, Chang <wcchang@infuseai.io>